### PR TITLE
Add JavaScript ES6 and beyond ebook

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1422,6 +1422,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [JavaScript Allongé](https://leanpub.com/javascript-allonge/read) - Reginald Braithwaite
 * [JavaScript Bible](http://media.wiley.com/product_ancillary/28/07645334/DOWNLOAD/all.pdf) (PDF)
 * [JavaScript Enlightenment](http://www.javascriptenlightenment.com) - Cody Lindley
+* [JavaScript ES6 and beyond](https://github.com/AlbertoMontalesi/JavaScript-es6-and-beyond-ebook) (PDF, epub) - Alberto Montalesi
 * [JavaScript For Cats](http://jsforcats.com)
 * [JavaScript Fundamentals, Plus a Dash Of JQuery - for dinner ladies](http://nicholasjohnson.com/javascript-book/)
 * [JavaScript Garden](http://bonsaiden.github.io/JavaScript-Garden/) (Maintained by Tim Ruffles)


### PR DESCRIPTION
Free e-book to learn new features from ES2015 to ES2018. Available freely to download in PDF and epub, no email required.